### PR TITLE
Fixing the plugin to work with latest version of Trello app

### DIFF
--- a/source/TrelloShortUrl.js
+++ b/source/TrelloShortUrl.js
@@ -17,8 +17,12 @@
         this.config = config;
         this.actionSelectorPrimary  = ".window-sidebar .other-actions .u-clearfix";
         this.actionSelectorFallback = ".window-sidebar .window-module:first-child .u-clearfix";
-        this.addButtonIfOnCard();
         this.listen();
+        (function (_this) {
+			setTimeout(function () {
+				_this.addButtonIfOnCard();
+			}, 1000);
+		})(this);
       }
 
       TrelloShortUrl.prototype.listen = function() {

--- a/source/TrelloShortUrl.js
+++ b/source/TrelloShortUrl.js
@@ -1,5 +1,14 @@
 (function() {
 
+
+  var headID = document.getElementsByTagName("head")[0];         
+  var newScript = document.createElement('script');
+  newScript.type = 'text/javascript';
+  newScript.src = chrome.extension.getURL('urlchange.js');
+  headID.appendChild(newScript);
+  
+  
+
   (function() {
     var TrelloShortUrl;
 
@@ -8,13 +17,14 @@
         this.config = config;
         this.actionSelectorPrimary  = ".window-sidebar .other-actions .u-clearfix";
         this.actionSelectorFallback = ".window-sidebar .window-module:first-child .u-clearfix";
+        this.addButtonIfOnCard();
         this.listen();
       }
 
       TrelloShortUrl.prototype.listen = function() {
         return window.addEventListener("message", (function(_this) {
           return function(event) {
-            if (event.data.trelloUrlChanged === null) {
+            if (! event.data.trelloUrlChanged) {
               return;
             }
             return _this.addButtonIfOnCard();

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -4,7 +4,11 @@
   "name": "Trello Short URL",
   "description": "This extension provides a button on a trello card to copy the short url to the clipboard.",
   "version": "0.3",
-
+  
+  "web_accessible_resources": [
+	"urlchange.js"
+  ],
+  
   "content_scripts" : [
     {
       "matches" : [ "https://trello.com/*" ],

--- a/source/urlchange.js
+++ b/source/urlchange.js
@@ -1,0 +1,7 @@
+window.history.pushState = (function(nativePushState) {
+    return function(a,b,c) {
+        window.postMessage({"trelloUrlChanged": true}, "*");
+        nativePushState.apply(this, arguments); //Continue by calling native history.pushState
+    };
+})(window.history.pushState);
+


### PR DESCRIPTION
When I tried to use the plugin yesterday it wouldn't work. I'm guessing the trello app used to publish its own "trelloUrlChanged" message, but it didn't look like that was happening anymore. The plugin now publishes the message itself based on `window.history` state changes.
